### PR TITLE
Bug/24 refresh token is not correctly reused

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -44,6 +44,7 @@ import { VerifyIdentityModalModule } from './pages/modals/verify-identity-modal/
 import { TutorialsProvider } from 'src/app/providers/data/tutorials.provider';
 import { AuthInterceptor } from 'src/app/interceptors/authentication.interceptor';
 import { LivechatWidgetModule } from '@livechat/angular-widget';
+import { SwipeluxInterceptor } from 'src/app/interceptors/swipelux.interceptor';
 
 @NgModule({
   declarations: [AppComponent],
@@ -88,6 +89,11 @@ import { LivechatWidgetModule } from '@livechat/angular-widget';
     LocalStorage,
     HTTP,
     Diagnostic,
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: SwipeluxInterceptor,
+      multi: true,
+    },
     {
       provide: HTTP_INTERCEPTORS,
       useClass: AuthInterceptor,

--- a/src/app/interceptors/swipelux.interceptor.ts
+++ b/src/app/interceptors/swipelux.interceptor.ts
@@ -1,0 +1,33 @@
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+} from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable} from '@polkadot/x-rxjs';
+import { HeaderFlags, ApiResources } from 'src/app/interface/global';
+import { SwipeluxProvider } from '../providers/swipelux/swipelux-provider.service';
+
+@Injectable()
+export class SwipeluxInterceptor implements HttpInterceptor {
+
+  constructor(
+    private swipeluxProvider: SwipeluxProvider,
+  ) {}
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+
+    if (req.headers.get(HeaderFlags.ApiResource) !== ApiResources.Swipelux) return next.handle(req);
+
+    const cloned = req.clone({
+      setHeaders: {
+        Authorization: this.swipeluxProvider.authToken ?? '',
+        'x-merchant-key': this.swipeluxProvider.merchantKey ?? '',
+      },
+    });
+
+    return next.handle(cloned);
+  }
+
+}

--- a/src/app/interface/global.ts
+++ b/src/app/interface/global.ts
@@ -2,3 +2,13 @@ export type ID = number;
 export type UUID = string;
 export type UniqueID = string;
 export type UserID = string; // represents email
+
+export enum HeaderFlags {
+	ApiResource = 'x-api-resource',
+}
+
+export enum ApiResources {
+	Simplio = 'simplio',
+	Swipelux = 'swipelux',
+	Anonymous = 'anonymous',
+}

--- a/src/app/interface/global.ts
+++ b/src/app/interface/global.ts
@@ -4,11 +4,11 @@ export type UniqueID = string;
 export type UserID = string; // represents email
 
 export enum HeaderFlags {
-	ApiResource = 'x-api-resource',
+  ApiResource = 'x-api-resource',
 }
 
 export enum ApiResources {
-	Simplio = 'simplio',
-	Swipelux = 'swipelux',
-	Anonymous = 'anonymous',
+  Simplio = 'simplio',
+  Swipelux = 'swipelux',
+  Anonymous = 'anonymous',
 }

--- a/src/app/pages/home.page.ts
+++ b/src/app/pages/home.page.ts
@@ -296,10 +296,6 @@ export class HomePage extends TrackedPage implements OnInit {
   };
 
   ionViewWillEnter() {
-    const acc = this.authProvider.accountValue;
-    if (this.auth.isValid(acc.atk)) this.swapConn.start({ token: acc.atk });
-    else this.auth.refresh(acc).then(a => this.swapConn.start({ token: a.atk }));
-
     const transactionsAPISubscription = this.transactionProvider.transactions$
       .pipe(filter(tx => !!tx))
       .subscribe(tx => {

--- a/src/app/pages/swap/swap-confirm/swap-confirm.page.ts
+++ b/src/app/pages/swap/swap-confirm/swap-confirm.page.ts
@@ -46,22 +46,7 @@ export class SwapConfirmPage implements OnInit, OnDestroy {
     this.dataService.cleanSwapTransaction();
   }
 
-  /**
-   * @todo saving the pending transaction is obsolete and it was removed why it is here?
-   */
-  onDone() {
-    const data = {
-      email: this.authProvider.accountValue.email,
-      swapTx: this.swapTx,
-    };
-
-    this.singleSwap
-      .savePendingSwap(data)
-      .then(() => this.router.navigate(['home', 'swap']))
-      .catch(async (err: Error) => {
-        console.error(err.message);
-        await this.utilService.showToast(this.$.SAVING_SWAP_HAS_FAILED, 1500, 'warning');
-        this.router.navigate(['home', 'swap']);
-      });
+  async onDone() {
+    await this.router.navigate(['home', 'swap']);
   }
 }

--- a/src/app/pages/swap/swap.page.ts
+++ b/src/app/pages/swap/swap.page.ts
@@ -33,6 +33,7 @@ import { coinNames } from 'src/app/services/api/coins';
 import { Stake, Pool } from '@simplio/backend/interface/stake';
 import { NetworkService } from 'src/app/services/apiv2/connection/network.service';
 import { PurchaseDetailModal } from '../modals/purchase-detail-modal/purchase-detail.modal';
+import { SwapConnectionService } from 'src/app/services/swap/swap-connection.service';
 
 const DEFAULTS = {
   currentPage: 0,
@@ -76,6 +77,7 @@ export class SwapPage extends TrackedPage implements OnInit, OnDestroy {
     private authProvider: AuthenticationProvider,
     private io: IoService,
     private networkService: NetworkService,
+    private swapConn: SwapConnectionService,
   ) {
     super();
     this.subscription.add(this.swapProvider.allPendingSwaps$.subscribe(_ => this.loadData()));
@@ -216,6 +218,9 @@ export class SwapPage extends TrackedPage implements OnInit, OnDestroy {
   ngOnInit() {
     this._isLoadingInit.next(true);
     this.loadData(true).then(_ => this._isLoadingInit.next(false));
+
+    const acc = this.authProvider.accountValue;
+    this.swapConn.start({ token: acc.atk });
   }
 
   ngOnDestroy() {
@@ -239,7 +244,6 @@ export class SwapPage extends TrackedPage implements OnInit, OnDestroy {
     const d = { pageNumber: 1, clean: false, ...data };
     const statuses = [SwapStatusText.Completed, SwapStatusText.Failed, SwapStatusText.Expired];
     try {
-      await this.authService.checkToken();
       const page = await this.singleSwap.report({
         pageNumber: d.pageNumber,
         swapStatus: statuses,
@@ -269,7 +273,6 @@ export class SwapPage extends TrackedPage implements OnInit, OnDestroy {
         SwapStatusText.Swapping,
         SwapStatusText.Withdrawing,
       ];
-      await this.authService.checkToken();
       const page = await this.singleSwap.report({
         pageNumber: 1,
         swapStatus: query,

--- a/src/app/providers/data/authentication.provider.ts
+++ b/src/app/providers/data/authentication.provider.ts
@@ -9,6 +9,7 @@ const defaults = {
   account: null,
   storeAccount: false,
   isAuthenticated: false,
+  isRefreshing: false,
   canRecover: true,
   autheticationErrors: null,
   accessTokenBody: null,
@@ -32,6 +33,9 @@ export class AuthenticationProvider {
 
   private _isAuthenticated = new BehaviorSubject<boolean>(defaults.isAuthenticated);
   isAuthenticated$ = this._isAuthenticated.asObservable();
+
+  private _isRefreshing = new BehaviorSubject<boolean>(defaults.isRefreshing);
+  isRefreshing$ = this._isRefreshing.asObservable();
 
   private _canRecover = new BehaviorSubject<boolean>(defaults.canRecover);
   canRecover$ = this._canRecover.asObservable();
@@ -98,6 +102,11 @@ export class AuthenticationProvider {
     if (opts.isNew) this._storeAccount.next(true);
 
     return account;
+  }
+
+  pushIsRefreshing(isRefreshing: boolean): boolean {
+    this._isRefreshing.next(isRefreshing);
+    return isRefreshing;
   }
 
   pushCanRecover(val: boolean): boolean {

--- a/src/app/services/authentication/account.service.ts
+++ b/src/app/services/authentication/account.service.ts
@@ -1,4 +1,4 @@
-import { HttpErrorResponse, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Acc } from 'src/app/interface/user';
 import { AccountRegistrationError } from 'src/app/providers/errors/account-registration-error';
@@ -24,9 +24,8 @@ export class AccountService {
   constructor(
     private $: Translate,
     private io: IoService,
-    private plt: PlatformProvider,
     private authProvider: AuthenticationProvider,
-    private http: HttpFallbackService,
+    private http: HttpClient,
   ) {}
 
   get canResetPassword(): boolean {
@@ -39,9 +38,12 @@ export class AccountService {
       'Content-Type': 'application/json',
     });
     const body = { emailAddress: email };
-    return this.http.post<void>(url, body, { headers }).catch((err: HttpErrorResponse) => {
-      throw new AccountRegistrationError(err, this.$);
-    });
+    return this.http
+      .post<void>(url, body, { headers })
+      .toPromise()
+      .catch((err: HttpErrorResponse) => {
+        throw new AccountRegistrationError(err, this.$);
+      });
   }
 
   changePassword(password: string): Promise<void> {
@@ -51,9 +53,12 @@ export class AccountService {
     });
     const body = { password };
 
-    return this.http.put<void>(url, body, { headers }).catch((err: HttpErrorResponse) => {
-      throw new AccountRegistrationError(err, this.$);
-    });
+    return this.http
+      .put<void>(url, body, { headers })
+      .toPromise()
+      .catch((err: HttpErrorResponse) => {
+        throw new AccountRegistrationError(err, this.$);
+      });
   }
 
   addAccount(account: Acc): Promise<Acc> {

--- a/src/app/services/authentication/authentication.service.ts
+++ b/src/app/services/authentication/authentication.service.ts
@@ -1,4 +1,4 @@
-import { HttpErrorResponse, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import {
   AccountCredentials,
@@ -10,15 +10,14 @@ import { IdentityVerificationError } from 'src/app/providers/errors/identity-ver
 import { Translate } from 'src/app/providers/translate';
 import { AuthenticationProvider } from '../../providers/data/authentication.provider';
 import { PlatformProvider } from '../../providers/platform/platform';
-import { USERS_URLS, USERS_URLS_V2 } from '../../providers/routes/account.routes';
 import { IoService } from '../io.service';
 import { parseJWT } from './utils';
 import { MultiFactorAuthenticationService } from './mfa.service';
+import { USERS_URLS, USERS_URLS_V2 } from 'src/app/providers/routes/swap.routes';
 import { AccountService } from 'src/app/services/authentication/account.service';
 import { SwapProvider } from '../../providers/data/swap.provider';
 import { HttpFallbackService } from '../apiv2/connection/http-fallback.service';
-import { CheckWalletsService } from '../wallets/check-wallets.service';
-import { TransactionsService } from '../transactions.service';
+import { HeadersService } from 'src/app/services/headers.service';
 
 type AfterLoginOptions = { verify: boolean; isNew: boolean };
 
@@ -28,10 +27,6 @@ type AfterLoginOptions = { verify: boolean; isNew: boolean };
 export class AuthenticationService {
   private reloadTimeout = null;
   private _refreshServerUrl = '';
-
-  private readonly RETRY_TIMEOUT = 3000; // in ms
-  private readonly MAX_ATTEMPTS_TO_RECONNECT = Number.MAX_SAFE_INTEGER;
-
   constructor(
     private $: Translate,
     private mfa: MultiFactorAuthenticationService,
@@ -39,8 +34,8 @@ export class AuthenticationService {
     private io: IoService,
     private authProvider: AuthenticationProvider,
     private swapProvider: SwapProvider,
-    private http: HttpFallbackService,
-    private acc: AccountService,
+    private http: HttpClient,
+    private acc: AccountService
   ) {}
 
   serverUrl() {
@@ -51,6 +46,7 @@ export class AuthenticationService {
     const url = USERS_URLS.access.href;
     const headers = new HttpHeaders({
       'Content-Type': 'application/json',
+      ...HeadersService.simplioHeaders,
     });
 
     const cred = {
@@ -61,6 +57,7 @@ export class AuthenticationService {
 
     return this.http
       .post<AccountCredentialsResponse>(url, cred, { headers })
+      .toPromise()
       .then(res => !!res.refresh_token);
   }
 
@@ -78,7 +75,6 @@ export class AuthenticationService {
   async login(cred: AccountCredentials, opt: Partial<AfterLoginOptions> = {}): Promise<Acc> {
     try {
       const cr = await this._login(cred);
-      // console.log(cr);
       const accountLog = await this.io.getLatestAccountLog(cred.userId);
 
       const o: AfterLoginOptions = {
@@ -100,7 +96,6 @@ export class AuthenticationService {
       const account = o.verify
         ? await this._verifyAccount(accountStruct, accountLog)
         : accountStruct;
-
       return this.authProvider.pushAccount(account, { isNew: o.isNew });
     } catch (err) {
       // TODO - resolve error here
@@ -115,36 +110,24 @@ export class AuthenticationService {
     });
   }
 
-  async refresh(acc: Acc, itteration = 0): Promise<Acc> {
+  refresh(acc: Acc): Promise<Acc> {
     return this._refresh(acc.rtk)
-      .then(c =>
-        this.acc.updateAccount({ rtk: c.refresh_token, atk: c.access_token, tkt: c.token_type }),
-      )
-      .catch(async _ => {
-        await new Promise(resolve => setTimeout(resolve, this.RETRY_TIMEOUT));
-
-        if (itteration < this.MAX_ATTEMPTS_TO_RECONNECT) {
-          // in case of lost connection, try again
-          console.log('Refresh failed, trying again...');
-          return this.refresh(acc, itteration + 1);
-        } else {
-          throw new Error('Refresh failed');
-        }
-      });
+      .then(c => this.acc.updateAccount({ 
+        rtk: c?.refresh_token ?? acc.rtk, 
+        atk: c.access_token, 
+        tkt: c.token_type 
+      }));
   }
 
   getAccountData(): Promise<RegisterAccountData> {
     const url = USERS_URLS.account.href;
     const headers = new HttpHeaders({
       'Content-Type': 'application/json',
+      ...HeadersService.simplioHeaders,
     });
-    return this.http.get<RegisterAccountData>(url, { headers });
-  }
-
-  async checkToken() {
-    if (!this.isValid(this.authProvider.accountValue.atk)) {
-      return this.refresh(this.authProvider.accountValue);
-    }
+    return this.http
+      .get<RegisterAccountData>(url, { headers })
+      .toPromise();
   }
 
   private _login(cred: AccountCredentials): Promise<AccountCredentialsResponse> {
@@ -162,6 +145,7 @@ export class AuthenticationService {
 
     return this.http
       .post<AccountCredentialsResponse>(url, cred, { headers })
+      .toPromise()
       .catch((err: HttpErrorResponse) => {
         if (err.status === 401) {
           let customErr = new HttpErrorResponse({
@@ -170,8 +154,8 @@ export class AuthenticationService {
             status: err.status,
             statusText: err.statusText,
             error: Object.freeze({
-              code: 'NO_SUCH_USER',
-            }),
+              code: 'NO_SUCH_USER'
+            })
           });
           if (err.error.includes('verify your email')) {
             customErr = new HttpErrorResponse({
@@ -186,7 +170,7 @@ export class AuthenticationService {
 
             throw new IdentityVerificationError(customErr, this.$);
           }
-        }
+        };
         throw err;
       });
   }
@@ -199,6 +183,7 @@ export class AuthenticationService {
 
     return this.http
       .post<AccountCredentialsResponse>(url, cred, { headers })
+      .toPromise()
       .catch((err: HttpErrorResponse) => {
         if (err.status === 401) {
           let customErr = new HttpErrorResponse({
@@ -229,7 +214,6 @@ export class AuthenticationService {
   }
 
   private _refresh(refreshToken: string): Promise<AccountCredentialsResponse> {
-    console.log('Refresh token');
     return this._refreshv1(refreshToken).catch(err => {
       return this._refreshv2(refreshToken).catch(_ => {
         throw err;
@@ -246,6 +230,7 @@ export class AuthenticationService {
 
     return this.http
       .post<AccountCredentialsResponse>(url, body, { headers })
+      .toPromise()
       .catch((err: HttpErrorResponse) => {
         if (err.status === 401) {
           const customErr = new HttpErrorResponse({
@@ -272,11 +257,9 @@ export class AuthenticationService {
 
     return this.http
       .post<AccountCredentialsResponse>(url, body, { headers })
-      .then(res => {
-        this._refreshServerUrl = url;
-        return res;
-      })
-      .catch((err: HttpErrorResponse) => {
+      .toPromise()
+      .catch(err => {
+        console.error(err);
         if (err.status === 401) {
           const customErr = new HttpErrorResponse({
             headers: err.headers,

--- a/src/app/services/authentication/registration.service.ts
+++ b/src/app/services/authentication/registration.service.ts
@@ -1,16 +1,15 @@
-import { HttpErrorResponse, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { AccountCredentials, AgreementData, RegisterAccountData } from 'src/app/interface/account';
 import { AccountRegistrationError } from 'src/app/providers/errors/account-registration-error';
 import { Translate } from 'src/app/providers/translate';
 import { USERS_URLS } from '../../providers/routes/account.routes';
-import { HttpFallbackService } from '../apiv2/connection/http-fallback.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class RegistrationService {
-  constructor(private $: Translate, private http: HttpFallbackService) {}
+  constructor(private $: Translate, private http: HttpClient) {}
 
   register(data: RegisterAccountData): Promise<AccountCredentials> {
     const url = USERS_URLS.account.href;
@@ -25,6 +24,7 @@ export class RegistrationService {
 
     return this.http
       .post<void>(url, body, { headers })
+      .toPromise()
       .then(() => data.cred)
       .catch((err: HttpErrorResponse) => {
         throw new AccountRegistrationError(err, this.$);
@@ -42,10 +42,10 @@ export class RegistrationService {
       agreements: JSON.stringify(data),
     };
 
-    return this.http.put(url, body, { headers });
+    return this.http.put(url, body, { headers }).toPromise();
   }
 
   getIpAddress(): Promise<string> {
-    return this.http.get<any>('http://www.ip-api.com/json').then(res => res.query);
+    return this.http.get<any>('http://www.ip-api.com/json').toPromise().then(res => res.query);
   }
 }

--- a/src/app/services/authentication/user-data.service.ts
+++ b/src/app/services/authentication/user-data.service.ts
@@ -1,5 +1,6 @@
-import { HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { HeadersService } from 'src/app/services/headers.service';
 import { USERS_URLS } from '../../providers/routes/account.routes';
 import { AGREEMENTS_URL } from '../../providers/routes/swap.routes';
 import { HttpFallbackService } from '../apiv2/connection/http-fallback.service';
@@ -20,16 +21,18 @@ export interface UserDataItem {
   providedIn: 'root',
 })
 export class UserDataService {
-  constructor(private http: HttpFallbackService) {}
+  constructor(private http: HttpClient) {}
 
   get(property: string): Promise<any> {
     const url = USERS_URLS.data.href;
     const headers = new HttpHeaders({
       'Content-Type': 'application/json',
+      ...HeadersService.simplioHeaders,
     });
 
     return this.http
       .get<UserDataItem[]>(url, { headers })
+      .toPromise()
       .then(res => res.find(a => a.Name === property)?.Value);
   }
 
@@ -37,6 +40,7 @@ export class UserDataService {
     const url = USERS_URLS.data.href;
     const headers = new HttpHeaders({
       'Content-Type': 'application/json',
+      ...HeadersService.simplioHeaders,
     });
     const body = {
       name,
@@ -44,13 +48,14 @@ export class UserDataService {
       value,
     };
 
-    return this.http.post<any>(url, body, { headers });
+    return this.http.post<any>(url, body, { headers }).toPromise();
   }
 
   update(name: string, type: string, value: string): Promise<any> {
     const url = USERS_URLS.data.href;
     const headers = new HttpHeaders({
       'Content-Type': 'application/json',
+      ...HeadersService.simplioHeaders,
     });
     const body = {
       name,
@@ -58,42 +63,46 @@ export class UserDataService {
       value,
     };
 
-    return this.http.put<any>(url, body, { headers });
+    return this.http.put<any>(url, body, { headers }).toPromise();
   }
 
   remove(name: string): Promise<any> {
     const url = `${USERS_URLS.data.href}/${name}`;
     const headers = new HttpHeaders({
       'Content-Type': 'application/json',
+      ...HeadersService.simplioHeaders,
     });
 
-    return this.http.delete<any>(url, { headers });
+    return this.http.delete<any>(url, { headers }).toPromise();
   }
 
   initializeAdvertising(advertising: boolean): Promise<any> {
     const url = AGREEMENTS_URL.agreements.href;
     const headers = new HttpHeaders({
       'Content-Type': 'application/json',
+      ...HeadersService.simplioHeaders,
     });
 
-    return this.http.post(url, { advertising }, { headers });
+    return this.http.post(url, { advertising }, { headers }).toPromise();
   }
 
   updateAdvertising(advertising: boolean): Promise<any> {
     const url = AGREEMENTS_URL.agreements.href;
     const headers = new HttpHeaders({
       'Content-Type': 'application/json',
+      ...HeadersService.simplioHeaders,
     });
 
-    return this.http.put(url, { advertising }, { headers });
+    return this.http.put(url, { advertising }, { headers }).toPromise();
   }
 
   getAdvertising(): Promise<boolean> {
     const url = AGREEMENTS_URL.agreements.href;
     const headers = new HttpHeaders({
       'Content-Type': 'application/json',
+      ...HeadersService.simplioHeaders,
     });
 
-    return this.http.get<any>(url, { headers }).then(res => res.Advertising);
+    return this.http.get<any>(url, { headers }).toPromise().then(res => res.Advertising);
   }
 }

--- a/src/app/services/headers.service.ts
+++ b/src/app/services/headers.service.ts
@@ -1,0 +1,18 @@
+
+import { Injectable } from '@angular/core';
+import { ApiResources, HeaderFlags } from 'src/app/interface/global';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class HeadersService {
+
+  static readonly simplioHeaders = {
+    [HeaderFlags.ApiResource]: ApiResources.Simplio,
+  }
+
+  static readonly swipeluxHeaders = {
+    [HeaderFlags.ApiResource]: ApiResources.Swipelux,
+  }
+
+}

--- a/src/app/services/kyc.service.ts
+++ b/src/app/services/kyc.service.ts
@@ -1,41 +1,43 @@
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { HeadersService } from 'src/app/services/headers.service';
 import { SumSubTokenResponse, VerificationRecord } from '../interface/kyc';
 import { AuthenticationProvider } from '../providers/data/authentication.provider';
 import { KYC_URLS } from '../providers/routes/account.routes';
 import { SwipeluxProvider } from '../providers/swipelux/swipelux-provider.service';
-import { HttpService } from './http.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class KycService {
   constructor(
-    private http: HttpService,
+    private http: HttpClient,
     private swipeluxProvider: SwipeluxProvider,
     private authProvider: AuthenticationProvider,
   ) {}
 
   getSharedToken(client = 'swipelux'): Promise<SumSubTokenResponse> {
     const url = KYC_URLS.shareToken.href;
-    const headers = this.http.getHttpHeaders('application/json', true);
 
-    return this.http.get<any>(url, { headers, params: { client } });
+    return this.http
+      .get<any>(url, { headers: HeadersService.simplioHeaders, params: { client } })
+      .toPromise();
   }
 
   getAccessToken(): Promise<SumSubTokenResponse> {
     const url = KYC_URLS.accessToken.href;
-    const headers = this.http.getHttpHeaders('application/json', true);
 
-    return this.http.get<any>(url, { headers });
+    return this.http
+      .get<any>(url, { headers: HeadersService.simplioHeaders })
+      .toPromise();
   }
 
   getVerificationsRecords(): Promise<VerificationRecord[]> {
     const url = KYC_URLS.verificationRecord.href;
-    const headers = this.http.getHttpHeaders('application/json', true);
 
     this.authProvider.pushSumsubStatus('');
     this.authProvider.pushVerificationRecord(null);
-    return this.http.get<any>(url, { headers }).then(records => {
+    return this.http.get<any>(url, { headers: HeadersService.simplioHeaders }).toPromise().then(records => {
       if (!!records) {
         const latestRecord = records.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))[0]; // get the latest record
         this.authProvider.pushVerificationRecord(latestRecord);

--- a/src/app/services/swap/single-swap.service.ts
+++ b/src/app/services/swap/single-swap.service.ts
@@ -1,6 +1,5 @@
 import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { SignedTransaction } from 'src/app/interface/data';
 import {
   SwapStatusText,
   SwapSingleResponse,
@@ -8,12 +7,11 @@ import {
   SwapConvertResponse,
   SwapReportRequestParams,
   SwapType,
-  SwapTransaction,
   SwapReportPage,
   SwapSingleUpdate,
 } from 'src/app/interface/swap';
 import { PlatformProvider } from 'src/app/providers/platform/platform';
-import { HttpFallbackService } from '../apiv2/connection/http-fallback.service';
+import { HeadersService } from 'src/app/services/headers.service';
 import { getParams } from '../authentication/utils';
 import { CommonSwap, SwapService } from './swap-common';
 
@@ -29,7 +27,7 @@ export class SingleSwapService extends CommonSwap implements SwapService {
   constructor(
     protected plt: PlatformProvider,
     protected platformProvider: PlatformProvider,
-    protected http: HttpFallbackService,
+    protected http: HttpClient,
   ) {
     super(plt, http, platformProvider);
   }
@@ -38,18 +36,23 @@ export class SingleSwapService extends CommonSwap implements SwapService {
     const url = this.URLS.singleSwap.href;
     const headers = new HttpHeaders({
       'Content-Type': 'application/json',
+      ...HeadersService.simplioHeaders,
     });
-    return this.http.post(url, swapTransaction, { headers });
+    return this.http
+      .post(url, swapTransaction, { headers })
+      .toPromise();
   }
 
   cancel(sagaId: string): Promise<void> {
     const url = this.URLS.singleSwap.href;
     const headers = new HttpHeaders({
       'Content-Type': 'application/json',
+      ...HeadersService.simplioHeaders,
     });
     const body = { sagaId };
     return this.http
       .request<void>('DELETE', url, { headers, body })
+      .toPromise()
       .catch((err: HttpErrorResponse) => {
         console.error('Cancelling swap has failed');
         throw err;
@@ -60,10 +63,13 @@ export class SingleSwapService extends CommonSwap implements SwapService {
     const url = this.URLS.singleSwapParams.href;
     const headers = new HttpHeaders({
       'Content-Type': 'application/json',
+      ...HeadersService.simplioHeaders,
     });
     const params = getParams(data);
 
-    return this.http.get<SwapConvertResponse>(url, { headers, params });
+    return this.http
+      .get<SwapConvertResponse>(url, { headers, params })
+      .toPromise();
   }
 
   report(data: ReportData): Promise<SwapReportPage> {
@@ -81,11 +87,12 @@ export class SingleSwapService extends CommonSwap implements SwapService {
     const url = this.URLS.singleSwap.href;
     const headers = new HttpHeaders({
       'Content-Type': 'application/json',
+      ...HeadersService.simplioHeaders,
     });
 
     return this.http
-      .put(url, data, { headers })
-      .then(() => {})
+      .put<void>(url, data, { headers })
+      .toPromise()
       .catch((err: HttpErrorResponse) => {
         console.error('Updating swap transaction has failed');
         throw err;
@@ -96,11 +103,12 @@ export class SingleSwapService extends CommonSwap implements SwapService {
     const url = this.URLS.linkedAccount.href;
     const headers = new HttpHeaders({
       'Content-Type': 'application/json',
+      ...HeadersService.simplioHeaders,
     });
 
     return this.http
       .get(url + '/' + address, { headers })
-
+      .toPromise()
       .catch((err: HttpErrorResponse) => {
         throw err;
       });
@@ -110,11 +118,12 @@ export class SingleSwapService extends CommonSwap implements SwapService {
     const url = this.USER_URLS.email.href;
     const headers = new HttpHeaders({
       'Content-Type': 'application/json',
+      ...HeadersService.simplioHeaders,
     });
 
     return this.http
       .post(url, { userId }, { headers })
-
+      .toPromise()
       .catch((err: HttpErrorResponse) => {
         throw err;
       });
@@ -124,26 +133,15 @@ export class SingleSwapService extends CommonSwap implements SwapService {
     const url = this.URLS.unlinkAddress.href;
     const headers = new HttpHeaders({
       'Content-Type': 'application/json',
+      ...HeadersService.simplioHeaders,
     });
 
     return this.http
       .delete(url + '/' + address, { headers })
-
+      .toPromise()
       .catch((err: HttpErrorResponse) => {
         throw err;
       });
   }
 
-  // obsolete
-  async savePendingSwap(data: {
-    email: string;
-    swapTx: SwapTransaction<SignedTransaction>;
-  }): Promise<void> {
-    const { email, swapTx } = data;
-    try {
-    } catch (err) {
-      console.error(err);
-      throw new Error('Saving swap has failed');
-    }
-  }
 }

--- a/src/app/services/swipelux/swipelux.service.ts
+++ b/src/app/services/swipelux/swipelux.service.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { map } from 'rxjs/operators';
+import { HeadersService } from 'src/app/services/headers.service';
 import {
   OrdersResponse,
   CurrencyPair,
@@ -21,7 +22,9 @@ export class SwipeluxService {
   cancelCurrentPayment(): Promise<any> {
     const url = SWIPELUX_URL.payment.href;
 
-    return this.http.delete(url, {}).toPromise();
+    return this.http.delete(url, { 
+      headers: HeadersService.swipeluxHeaders,
+     }).toPromise();
   }
 
   createOrderByShareToken(
@@ -29,34 +32,37 @@ export class SwipeluxService {
   ): Promise<{ accessToken: string; orderId: string }> {
     const url = SWIPELUX_URL.orders.href;
 
-    return this.http.post(url, order).toPromise<any>();
+    return this.http
+      .post<any>(url, order, { headers: HeadersService.swipeluxHeaders })
+      .toPromise();
   }
 
   getAllOrders(params?: any): Promise<{ items: OrdersResponse[]; pageInfo: any }> {
     const url = SWIPELUX_URL.orders.href;
 
     return this.http
-      .get(url, {
+      .get<any>(url, {
+        headers: HeadersService.swipeluxHeaders,
         params: getParams({
           sort: 'created_at',
           dir: 'desc',
           ...params,
         }),
       })
-      .toPromise() as any;
+      .toPromise();
   }
 
   getCurrentOrder(): Promise<OrderResponse> {
     const url = SWIPELUX_URL.currentOrders.href;
 
-    return this.http.get(url).toPromise() as any;
+    return this.http.get<any>(url, { headers: HeadersService.swipeluxHeaders }).toPromise();
   }
 
   getKycStatus(): Promise<{ passed: boolean; origin?: string; token?: string }> {
     const url = SWIPELUX_URL.kycVerification.href;
 
     return this.http
-      .get<any>(url, { observe: 'response' })
+      .get<any>(url, { observe: 'response', headers: HeadersService.swipeluxHeaders })
       .pipe(
         map(res => {
           if (res.status === 200) {
@@ -68,25 +74,26 @@ export class SwipeluxService {
           }
         }),
       )
-      .toPromise<any>();
+      .toPromise();
   }
 
   getPairs(): Promise<{ items: CurrencyPair[]; pageInfo: any }> {
     const url = SWIPELUX_URL.pairs.href;
 
     return this.http
-      .get(url, {
+      .get<any>(url, {
+        headers: HeadersService.swipeluxHeaders,
         params: {
           limit: 999,
         },
       })
-      .toPromise<any>();
+      .toPromise();
   }
 
   getRateFromTo(fromCcy: string, toCcy: string): Promise<RateResponse> {
     const url = `${SWIPELUX_URL.fromTo.href}/${fromCcy}/${toCcy}/rate`;
 
-    return this.http.get(url).toPromise<any>();
+    return this.http.get<any>(url, { headers: HeadersService.swipeluxHeaders }).toPromise();
   }
 
   initializePayment(): Promise<{
@@ -96,6 +103,6 @@ export class SwipeluxService {
   }> {
     const url = SWIPELUX_URL.payment.href;
 
-    return this.http.get(url).toPromise<any>();
+    return this.http.get<any>(url, { headers: HeadersService.swipeluxHeaders }).toPromise();
   }
 }

--- a/src/app/services/swipelux/swipelux.service.ts
+++ b/src/app/services/swipelux/swipelux.service.ts
@@ -22,9 +22,11 @@ export class SwipeluxService {
   cancelCurrentPayment(): Promise<any> {
     const url = SWIPELUX_URL.payment.href;
 
-    return this.http.delete(url, { 
-      headers: HeadersService.swipeluxHeaders,
-     }).toPromise();
+    return this.http
+      .delete(url, {
+        headers: HeadersService.swipeluxHeaders,
+      })
+      .toPromise();
   }
 
   createOrderByShareToken(
@@ -32,9 +34,7 @@ export class SwipeluxService {
   ): Promise<{ accessToken: string; orderId: string }> {
     const url = SWIPELUX_URL.orders.href;
 
-    return this.http
-      .post<any>(url, order, { headers: HeadersService.swipeluxHeaders })
-      .toPromise();
+    return this.http.post<any>(url, order, { headers: HeadersService.swipeluxHeaders }).toPromise();
   }
 
   getAllOrders(params?: any): Promise<{ items: OrdersResponse[]; pageInfo: any }> {
@@ -42,7 +42,7 @@ export class SwipeluxService {
 
     return this.http
       .get<any>(url, {
-        headers: HeadersService.swipeluxHeaders,
+        headers: HeadersService.simplioHeaders,
         params: getParams({
           sort: 'created_at',
           dir: 'desc',


### PR DESCRIPTION
# Overview

Refresh token is rotated on each its generation. Client did not paused http calls and refreshed token too many times. At the end an incorrect refresh token was store to local storage.

## Solution

Switching http provider to a default angular `HttpClient` allows us to use http interceptors and resolve token refreshing on their level. Cors will be solved on our backend.

By using multiple interceptors we can decouple logic for every backend. To be able to trigger a specific interceptor we use a http custom headers `x-api-resource`.

## Important

Please check if all http calls related to our backend are using correct interceptor.

## Test

- check entire authentication flow
- Wait min 30 seconds (temporary duration) if swap or reaching data from our server works
- Check if there is no logout after 30 seconds
- Check if swap works
- Check if user action in settings work (password change,...)